### PR TITLE
Prevent long term caching of repomd.xml in yum repos 

### DIFF
--- a/cmd/content-mirror/template_nginx.go
+++ b/cmd/content-mirror/template_nginx.go
@@ -75,6 +75,31 @@ http {
       proxy_ssl_certificate_key {{ .KeyPath }};
       {{- end }}
       {{- end }}
+
+      # Do not cache repomd.xml for long. These need to be pulled from the
+      # mirrored server regularly. When a yum repository is rebuilt, references in an old
+      # copy of repomd.xml will no longer resolve - resulting in 404s.
+      location ~ ^.*/(repodata/repomd\.xml) {
+        proxy_pass {{ .URL }}$1;
+        
+        proxy_cache_valid 200 206 60s; 
+        
+        proxy_set_header Host {{ index .Hosts 0 }};
+        
+        {{- if .TLS }}
+        proxy_ssl_session_reuse on;
+        {{- if gt (len .CACertificatePath) 0 }}
+        proxy_ssl_verify       on;
+        proxy_ssl_trusted_certificate {{ .CACertificatePath }};
+        {{- end }}
+        {{- if gt (len .CertificatePath) 0 }}
+        proxy_ssl_certificate     {{ .CertificatePath }};
+        proxy_ssl_certificate_key {{ .KeyPath }};
+        {{- end }}
+        {{- end }}
+      
+      }
+
     }
     location = /{{ .Name }} {
       rewrite ^ /{{ .Name }}/ redirect;


### PR DESCRIPTION
When mirroring a yum repository, if the repo is updated on the
mirrored server, any cached repomd.xml will contain references
to files that no longer exist on the server.
Prevent this by frequently refreshing the repomd.xml files to
minimize this window.

Example in the wild: https://coreos.slack.com/archives/CB95J6R4N/p1614086128039800
```
Errors during downloading metadata for repository 'rhel-8-server-ose':
  - Status code: 404 for http://base-4-8-rhel8.ocp.svc/rhel-8-server-ose/repodata/263b221dcd5de44798854a2070226c15d34a6cc24f95ada91d0274eda0ac74e1-filelists.xml.gz (IP: 172.30.176.11)
```