### PR TITLE
Allow chmod to fail on read-only areas of the file system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,13 @@ RUN GOPATH=/go go install github.com/openshift/content-mirror/cmd/content-mirror
 FROM centos:7
 COPY --from=0 /go/bin/content-mirror /usr/bin/content-mirror
 COPY nginx.repo /etc/yum.repos.d/nginx.repo
+# Note: nginx creates "/var/run/nginx.pid". Runtime user needs to be able to create this file.
 RUN INSTALL_PKGS=" \
       nginx \
       " && \
     yum install --enablerepo=nginx -y ${INSTALL_PKGS} && rpm -V ${INSTALL_PKGS} && \
     yum clean all && \
     rm -rf /var/lib/rpm /var/lib/yum/history && \
-    chmod -R uga+rwx /var/cache/nginx /var/log/nginx /run
+    chmod -R uga+rwx /var/cache/nginx /var/log/nginx && \
+    chmod uga+rwx /var/run
 USER 1001


### PR DESCRIPTION
Looks like a change in behavior since this was last built. Snippet from app.ci buildconfig logs..
```
....
Maybe you want: rm -rf /var/cache/yum, to also free up space taken by orphaned data from disabled or removed repos
Cleaning up list of fastest mirrors
chmod: changing permissions of '/run/secrets': Read-only file system
chmod: changing permissions of '/run/secrets/kubernetes.io': Read-only file system
chmod: changing permissions of '/run/secrets/kubernetes.io/serviceaccount': Read-only file system
chmod: changing permissions of '/run/secrets/kubernetes.io/serviceaccount/..2021_02_23_21_31_54.985003925': Read-only file system
chmod: changing permissions of '/run/secrets/kubernetes.io/serviceaccount/..2021_02_23_21_31_54.985003925/token': Read-only file system
chmod: changing permissions of '/run/secrets/kubernetes.io/serviceaccount/..2021_02_23_21_31_54.985003925/service-ca.crt': Read-only file system
chmod: changing permissions of '/run/secrets/kubernetes.io/serviceaccount/..2021_02_23_21_31_54.985003925/namespace': Read-only file system
chmod: changing permissions of '/run/secrets/kubernetes.io/serviceaccount/..2021_02_23_21_31_54.985003925/ca.crt': Read-only file system
chmod: changing permissions of '/run/secrets/openshift.io': Read-only file system
chmod: changing permissions of '/run/secrets/openshift.io/push': Read-only file system
chmod: changing permissions of '/run/secrets/openshift.io/push/..2021_02_23_21_31_54.556844430': Read-only file system
chmod: changing permissions of '/run/secrets/openshift.io/push/..2021_02_23_21_31_54.556844430/.dockercfg': Read-only file system
chmod: changing permissions of '/run/secrets/openshift.io/pull': Read-only file system
chmod: changing permissions of '/run/secrets/openshift.io/pull/..2021_02_23_21_31_54.770157040': Read-only file system
chmod: changing permissions of '/run/secrets/openshift.io/pull/..2021_02_23_21_31_54.770157040/.dockercfg': Read-only file system
chmod: changing permissions of '/run/secrets/rhsm': Read-only file system
chmod: changing permissions of '/run/secrets/rhsm/ca': Read-only file system
chmod: changing permissions of '/run/secrets/rhsm/ca/redhat-uep.pem': Read-only file system
chmod: changing permissions of '/run/secrets/rhsm/ca/redhat-entitlement-authority.pem': Read-only file system
subprocess exited with status 1
subprocess exited with status 1
error: build error: error building at STEP "RUN INSTALL_PKGS="       nginx       " &&     yum install --enablerepo=nginx -y ${INSTALL_PKGS} && rpm -V ${INSTALL_PKGS} &&     yum clean all &&     rm -rf /var/lib/rpm /var/lib/yum/history &&     chmod -R uga+rwx /var/cache/nginx /var/log/nginx /run": exit status 1
```

Looks like the original `chmod -R` on `/run` was to allow the pid file creation in `/var/run`. Eliminating `-R` accomplishes this without the errors. 