### PR TITLE
Enable basic auth and CDN hostname routing

### DIFF
--- a/cmd/content-mirror/main.go
+++ b/cmd/content-mirror/main.go
@@ -92,7 +92,7 @@ func (opt *Options) Run() error {
 	generator := config.NewGenerator(opt.ConfigPath, t, cacheConfig)
 	r := NewReloadManager(generator, process)
 
-	// the watcher coalesceses frequent file changes
+	// the watcher coalesces frequent file changes
 	w := watcher.New(opt.Paths, r.Load)
 	w.SetMinimumInterval(10 * time.Millisecond)
 	w.SetMaxDelays(100)

--- a/pkg/config/rpm.go
+++ b/pkg/config/rpm.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	b64 "encoding/base64"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/url"
@@ -20,22 +22,57 @@ type RPMRepositorySection struct {
 	SSLClientCert string `ini:"sslclientcert"`
 }
 
-func LoadRPMRepoUpstreams(iniFile string) ([]Upstream, error) {
+func getUsernamePassword(section *ini.Section) (string, error) {
+	// If a dnf section contains username_file/password_file, the content of those
+	// files is read and returned as "<username>:<password>". The non-standard keys
+	// are also removed from the ini Section. If their are no auth key files,
+	// "" is returned.
+	const usernameFileKey = "username_file"
+	const passwordFileKey = "password_file"
+	usernamePassword := ""
+	if section.HasKey(usernameFileKey) || section.HasKey(passwordFileKey) {
+		if !(section.HasKey(usernameFileKey) && section.HasKey(passwordFileKey)) {
+			return "", fmt.Errorf("%s and %s must both be specified", usernameFileKey, passwordFileKey)
+		}
+		// Load username from file and remove nonstandard key
+		usernameIn, err := ioutil.ReadFile(section.Key(usernameFileKey).Value())
+		if err != nil {
+			return "", fmt.Errorf("unable to read %s: %v", usernameFileKey, err)
+		}
+		section.DeleteKey(usernameFileKey)
+
+		// Load password from file and remove nonstandard key
+		passwordIn, err := ioutil.ReadFile(section.Key(passwordFileKey).Value())
+		if err != nil {
+			return "", fmt.Errorf("unable to read %s: %v", passwordFileKey, err)
+		}
+		section.DeleteKey(passwordFileKey)
+		usernamePassword = fmt.Sprintf("%s:%s", strings.TrimSpace(string(usernameIn)), strings.TrimSpace(string(passwordIn)))
+	}
+	return usernamePassword, nil
+}
+
+func LoadRPMRepoUpstreams(iniFile string) ([]Upstream, []RepoProxy, error) {
 	var upstreams []Upstream
+	var repoProxies []RepoProxy
 	cfg, err := ini.Load(iniFile)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for _, section := range cfg.Sections() {
 		if !section.Haskey("baseurl") {
 			continue
+		}
+		usernamePassword, err := getUsernamePassword(section)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s can't load section %s authentication: %v", iniFile, section.Name(), err)
 		}
 		repo := &RPMRepositorySection{
 			ID:      section.Name(),
 			Enabled: 1,
 		}
 		if err := section.MapTo(repo); err != nil {
-			return nil, fmt.Errorf("%s can't load section %s: %v", iniFile, section.Name(), err)
+			return nil, nil, fmt.Errorf("%s can't load section %s: %v", iniFile, section.Name(), err)
 		}
 		if repo.Enabled == 0 {
 			continue
@@ -48,7 +85,7 @@ func LoadRPMRepoUpstreams(iniFile string) ([]Upstream, error) {
 			}
 			url, err := url.Parse(u)
 			if err != nil {
-				return nil, fmt.Errorf("repo %s has a base URL that is not a valid URL: %v", iniFile, u)
+				return nil, nil, fmt.Errorf("repo %s has a base URL that is not a valid URL: %v", iniFile, u)
 			}
 			if !strings.HasSuffix(url.Path, "/") {
 				url.Path += "/"
@@ -56,7 +93,7 @@ func LoadRPMRepoUpstreams(iniFile string) ([]Upstream, error) {
 			urls = append(urls, url)
 		}
 		if len(urls) == 0 {
-			return nil, fmt.Errorf("repo %s has no baseurls", iniFile)
+			return nil, nil, fmt.Errorf("repo %s has no baseurls", iniFile)
 		}
 		var hosts []string
 		proxyPassURL := urls[0]
@@ -76,20 +113,38 @@ func LoadRPMRepoUpstreams(iniFile string) ([]Upstream, error) {
 		if len(hosts) != len(urls) {
 			log.Printf("one or more baseurls were omitted because they don't have a consistent path: %s", proxyPassURL.Path)
 		}
-		proxyPassURL.Host = repo.ID
+
+		// nginx uses the Upstream name as the hostname for SSL connections. To support public
+		// cloud CDN which depends on that hostname to forward requests appropriately, ensure
+		// that the Upstream name matches a hostname.
+		proxyPassURL.Host, _, err = net.SplitHostPort(hosts[0])
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to isolate host: %v", err)
+		}
 
 		upstream := Upstream{
-			Repo:  true,
-			Name:  repo.ID,
-			Hosts: hosts,
-			URL:   proxyPassURL.String(),
+			Repo:   true,
+			Name:   proxyPassURL.Host,
+			Hosts:  hosts,
 		}
+
+		repoProxy := RepoProxy{
+			RepoID:   repo.ID,
+			URL:      proxyPassURL.String(),
+			Upstream: hosts[0],
+		}
+
 		if len(repo.SSLClientCert) > 0 {
-			upstream.TLS = true
-			upstream.CertificatePath = makePathRelativeToFile(iniFile, repo.SSLClientCert)
-			upstream.KeyPath = makePathRelativeToFile(iniFile, repo.SSLClientKey)
+			repoProxy.TLS = true
+			repoProxy.CertificatePath = makePathRelativeToFile(iniFile, repo.SSLClientCert)
+			repoProxy.KeyPath = makePathRelativeToFile(iniFile, repo.SSLClientKey)
 		}
+		if len(usernamePassword) > 0 {
+			repoProxy.AuthHeader = "Basic " + b64.StdEncoding.EncodeToString([]byte(usernamePassword))
+		}
+		repoProxies = append(repoProxies, repoProxy)
 		upstreams = append(upstreams, upstream)
 	}
-	return upstreams, nil
+
+	return upstreams, repoProxies, nil
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -8,8 +8,9 @@ type CacheConfig struct {
 
 	LogLevel string
 
-	Frontends []Frontend
-	Upstreams []Upstream
+	Frontends   []Frontend
+	Upstreams   []Upstream
+	RepoProxies []RepoProxy
 }
 
 type Frontend struct {
@@ -20,13 +21,19 @@ type Frontend struct {
 
 type Upstream struct {
 	Name  string
-	URL   string
 	Hosts []string
 
 	Repo bool
+}
+
+type RepoProxy struct {
+	RepoID   string
+	URL      string
+	Upstream string
 
 	TLS               bool
 	CACertificatePath string
 	CertificatePath   string
 	KeyPath           string
+	AuthHeader        string
 }


### PR DESCRIPTION
- Provides for enabling basic auth username & password for yum repos. The yum repo config should define `username_file` and `password_file`. These files should be mounted in with secrets and the reverse proxy will ensure that an authorization header is added to all requests to the yum repository. 
- Decouples upstream definitions from repo definitions. Upstreams can now be shared. The reason being that ngnix uses the upstream name as the name of the host for the purposes of TLS. For a public cloud CDN, this hostname is critical to route to the appropriate backend.

Testing on apps.ci where `base-4-8-test` is running this commit. Comparing repo files -- only baseurl differs:
```diff
$ diff <( curl base-4-8-test.ocp.svc ) <( curl base-4-8.ocp.svc )
< baseurl = http://base-4-8-test.ocp.svc/rhel-server
---
> baseurl = http://base-4-8.ocp.svc/rhel-server
12c12
< baseurl = http://base-4-8-test.ocp.svc/rhel-server-optional
---
> baseurl = http://base-4-8.ocp.svc/rhel-server-optional
19c19
< baseurl = http://base-4-8-test.ocp.svc/rhel-server-extras
---
> baseurl = http://base-4-8.ocp.svc/rhel-server-extras
26c26
< baseurl = http://base-4-8-test.ocp.svc/rhel-server-ose
---
> baseurl = http://base-4-8.ocp.svc/rhel-server-ose
33c33
< baseurl = http://base-4-8-test.ocp.svc/rhel-fast-datapath
---
> baseurl = http://base-4-8.ocp.svc/rhel-fast-datapath
40c40
< baseurl = http://base-4-8-test.ocp.svc/rhel-server-rhscl
---
> baseurl = http://base-4-8.ocp.svc/rhel-server-rhscl
47c47
< baseurl = http://base-4-8-test.ocp.svc/rhel-ansible-2.9
---
> baseurl = http://base-4-8.ocp.svc/rhel-ansible-2.9
```

Testing difference in html listing (`a hrefs` are relative, so the output is identical):
```bash
$ diff <( curl -H "Accept: text/html"  base-4-8-test.ocp.svc ) <( curl -H "Accept: text/html" base-4-8.ocp.svc )
<none>
```

(repo listing trailing slash)
```diff
$ diff <( curl  base-4-8-test.ocp.svc/rhel-server/ ) <( curl base-4-8.ocp.svc/rhel-server/ )
<none>
```

(file access)
```
diff <( curl  base-4-8-test.ocp.svc/rhel-server/repodata/repomd.xml ) <( curl base-4-8.ocp.svc/rhel-server/repodata/repomd.xml )
<none>
```

Tested successfully on apps.ci with repo setup pointing to mirror2.openshift.com with `username_file` and `username_password` . 