### PR TITLE
Revert "Ensure ngnix resolves upstream IP"

### DIFF
--- a/cmd/content-mirror/template_nginx.go
+++ b/cmd/content-mirror/template_nginx.go
@@ -56,13 +56,9 @@ http {
     # it could be "close" to close a keepalive connection
     proxy_set_header Connection "";
 
-    {{ range $i, $rp := $repoProxies -}}
-
-
-	set $repo{{ $i }}_backend {{ .URL }}; 
-
+    {{ range $repoProxies -}}
     location /{{ .RepoID }}/ {
-      proxy_pass $repo{{ $i }}_backend;
+      proxy_pass {{ .URL }};
 
       proxy_ssl_server_name on;
 
@@ -91,7 +87,7 @@ http {
       # mirrored server regularly. When a yum repository is rebuilt, references in an old
       # copy of repomd.xml will no longer resolve - resulting in 404s.
       location ~ ^.*/(repodata/repomd\.xml) {
-        proxy_pass $repo{{ $i }}_backend$1;
+        proxy_pass {{ .URL }}$1;
         
         proxy_cache_valid 200 206 60s; 
         
@@ -115,11 +111,9 @@ http {
       }
 
     }
-
     location = /{{ .RepoID }} {
       rewrite ^ /{{ .RepoID }}/ redirect;
     }
-
     {{- if gt $config.LocalPort 0 }}
     location /{{ .RepoID }} {
       proxy_pass http://localhost;
@@ -127,9 +121,7 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
-
     {{- end }}
-
     {{- end }}
 
     {{- if gt $config.LocalPort 0 }}


### PR DESCRIPTION
Reverts openshift/content-mirror#6

When deployed, errors where reported like:
```

rhel-8-baseos                                   8.5 kB/s | 2.0 kB     00:00    
Errors during downloading metadata for repository 'rhel-8-baseos':
  - Downloading successful, but checksum doesn't match. Calculated: c6356ff13145887aeb8ba52e39e2250715e657fafc0675998cbeda8ebeebd5ae(sha256)  Expected: 759921aa9726e2c84f56dd494bfbca0fe5135fb423ec18ecd7f5ede9ca04484b(sha256) 
  - Downloading successful, but checksum doesn't match. Calculated: c6356ff13145887aeb8ba52e39e2250715e657fafc0675998cbeda8ebeebd5ae(sha256)  Expected: 4a682d45c07557ab817f9e59ff7a628145bdf6688cd902b1ca666e8090aa555b(sha256) 
  - Downloading successful, but checksum doesn't match. Calculated: c6356ff13145887aeb8ba52e39e2250715e657fafc0675998cbeda8ebeebd5ae(sha256)  Expected: 682e14289e9bf92236179b5900aa72f218cbac473627f5cf4d774b95a951d32d(sha256) 
Error: Failed to download metadata for repo 'rhel-8-baseos': Yum repo downloading error: Downloading error(s): repodata/4a682d45c07557ab817f9e59ff7a628145bdf6688cd902b1ca666e8090aa555b-primary.xml.gz - Cannot download, all mirrors were already tried without success; repodata/682e14289e9bf92236179b5900aa72f218cbac473627f5cf4d774b95a951d32d-filelists.xml.gz - Cannot download, all mirrors were already tried without success; repodata/759921aa9726e2c84f56dd494bfbca0fe5135fb423ec18ecd7f5ede9ca04484b-comps.xml - Cannot download, all mirrors were already tried without success; repodata/1398759f-f67f-41bd-ad8f-75d6fa9de836 - Cannot download, all mirrors were already tried without success; repodata/d1bb8cb01e31220ab35d0f8d535abaf937f2231101cb86326bb92413d7129a13-updateinfo.xml.gz - Cannot download, all mirrors were already tried without success 
```