### PR TITLE
[OCPCRT-291] Restart ngnix on url update

### DIFF
--- a/cmd/content-mirror/http.go
+++ b/cmd/content-mirror/http.go
@@ -65,11 +65,13 @@ func NewHandlers(config ConfigAccessor) (http.Handler, error) {
 			_, err := http.Get(url)
 			if err != nil {
 				// URL is not valid or there was an error accessing it
+				w.WriteHeader(http.StatusInternalServerError)
 				fmt.Fprintln(w, "not ok")
 				return
 			}
 		}
 
+		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, "ok")
 	}))
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/cmd/content-mirror/http.go
+++ b/cmd/content-mirror/http.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	htmltemplate "html/template"
-	"io"
 	"log"
 	"mime"
 	"net/http"
@@ -58,23 +57,6 @@ func NewHandlers(config ConfigAccessor) (http.Handler, error) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		lastConfig := config.LastConfig()
-
-		for _, repoProxy := range lastConfig.RepoProxies {
-			url := repoProxy.URL + "/repodata/repomd.xml"
-
-			response, responseErr := http.Get(url)
-
-			body, readError := io.ReadAll(response.Body)
-
-			if responseErr != nil || readError != nil || len(body) == 0 {
-				w.WriteHeader(http.StatusInternalServerError)
-				fmt.Fprintln(w, "not ok")
-				return
-			}
-		}
-
-		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, "ok")
 	}))
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/cmd/content-mirror/http.go
+++ b/cmd/content-mirror/http.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	htmltemplate "html/template"
+	"io"
 	"log"
 	"mime"
 	"net/http"
@@ -60,11 +61,13 @@ func NewHandlers(config ConfigAccessor) (http.Handler, error) {
 		lastConfig := config.LastConfig()
 
 		for _, repoProxy := range lastConfig.RepoProxies {
-			url := repoProxy.URL
+			url := repoProxy.URL + "/repodata/repomd.xml"
 
-			_, err := http.Get(url)
-			if err != nil {
-				// URL is not valid or there was an error accessing it
+			response, responseErr := http.Get(url)
+
+			body, readError := io.ReadAll(response.Body)
+
+			if responseErr != nil || readError != nil || len(body) == 0 {
 				w.WriteHeader(http.StatusInternalServerError)
 				fmt.Fprintln(w, "not ok")
 				return

--- a/cmd/content-mirror/http.go
+++ b/cmd/content-mirror/http.go
@@ -57,6 +57,19 @@ func NewHandlers(config ConfigAccessor) (http.Handler, error) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		lastConfig := config.LastConfig()
+
+		for _, repoProxy := range lastConfig.RepoProxies {
+			url := repoProxy.URL
+
+			_, err := http.Get(url)
+			if err != nil {
+				// URL is not valid or there was an error accessing it
+				fmt.Fprintln(w, "not ok")
+				return
+			}
+		}
+
 		fmt.Fprintln(w, "ok")
 	}))
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -8,9 +8,10 @@ type CacheConfig struct {
 
 	LogLevel string
 
-	Frontends   []Frontend
-	Upstreams   []Upstream
-	RepoProxies []RepoProxy
+	Frontends     []Frontend
+	Upstreams     []Upstream
+	RepoProxies   []RepoProxy
+	RepoProxyMaps map[string]bool
 }
 
 type Frontend struct {


### PR DESCRIPTION
If the repo endpoint can't be accessed, after we had managed to atleast once in the past, restart ngnix.