### PR TITLE
CNF-23375: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/config/generator.go
+++ b/pkg/config/generator.go
@@ -3,8 +3,8 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -36,7 +36,7 @@ func (m *Generator) Load(paths []string) error {
 	upstreamDefined := make(map[string]bool)
 
 	for _, p := range paths {
-		files, err := ioutil.ReadDir(p)
+		files, err := os.ReadDir(p)
 		if err != nil {
 			return err
 		}
@@ -57,7 +57,7 @@ func (m *Generator) Load(paths []string) error {
 				}
 				repoProxies = append(repoProxies, rpmRepoProxies...)
 				for _, upstream := range rpmUpstreams {
-					if _, ok := upstreamDefined[upstream.Name]; !ok {  // Dedupe upstreams
+					if _, ok := upstreamDefined[upstream.Name]; !ok { // Dedupe upstreams
 						upstreamDefined[upstream.Name] = true
 						upstreams = append(upstreams, upstream)
 					}
@@ -76,7 +76,7 @@ func (m *Generator) Load(paths []string) error {
 	if len(m.configPath) == 0 {
 		log.Printf("template:\n%s", buf.String())
 	} else {
-		if err := ioutil.WriteFile(m.configPath, buf.Bytes(), 0640); err != nil {
+		if err := os.WriteFile(m.configPath, buf.Bytes(), 0640); err != nil {
 			return err
 		}
 	}

--- a/pkg/config/rpm.go
+++ b/pkg/config/rpm.go
@@ -3,10 +3,10 @@ package config
 import (
 	b64 "encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/go-ini/ini"
@@ -35,14 +35,14 @@ func getUsernamePassword(section *ini.Section) (string, error) {
 			return "", fmt.Errorf("%s and %s must both be specified", usernameFileKey, passwordFileKey)
 		}
 		// Load username from file and remove nonstandard key
-		usernameIn, err := ioutil.ReadFile(section.Key(usernameFileKey).Value())
+		usernameIn, err := os.ReadFile(section.Key(usernameFileKey).Value())
 		if err != nil {
 			return "", fmt.Errorf("unable to read %s: %v", usernameFileKey, err)
 		}
 		section.DeleteKey(usernameFileKey)
 
 		// Load password from file and remove nonstandard key
-		passwordIn, err := ioutil.ReadFile(section.Key(passwordFileKey).Value())
+		passwordIn, err := os.ReadFile(section.Key(passwordFileKey).Value())
 		if err != nil {
 			return "", fmt.Errorf("unable to read %s: %v", passwordFileKey, err)
 		}
@@ -123,9 +123,9 @@ func LoadRPMRepoUpstreams(iniFile string) ([]Upstream, []RepoProxy, error) {
 		}
 
 		upstream := Upstream{
-			Repo:   true,
-			Name:   proxyPassURL.Host,
-			Hosts:  hosts,
+			Repo:  true,
+			Name:  proxyPassURL.Host,
+			Hosts: hosts,
 		}
 
 		repoProxy := RepoProxy{


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

**Migration from `ioutil` to `os`:**

* Replaced `ioutil.ReadDir` with `os.ReadDir` for reading directory contents in `generator.go`.
* Replaced `ioutil.WriteFile` with `os.WriteFile` for writing files in `generator.go`.
* Replaced `ioutil.ReadFile` with `os.ReadFile` for reading files in `rpm.go`.
* Updated import statements to remove `ioutil` and add `os` where necessary in both `generator.go` and `rpm.go`. [[1]](diffhunk://#diff-2780ed9e2d98a3d218ae6076f3d19ef22c3f022532fb10c38b333c63ed6dbed6L6-R7) [[2]](diffhunk://#diff-8b76524e93b43679ddeee640abf0eb1391b79196db360d6cd4f88780517a59bbL6-R9)