### PR TITLE
Disabled ipv6 and forcing IP refresh

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,5 +1,5 @@
 build_root_image:
   use_build_cache: true
-  namespace: openshift
-  name: release
-  tag: golang-1.23
+  namespace: ocp
+  name: builder
+  tag: rhel-9-golang-1.25-openshift-4.22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ci/origin-release:golang-1.23
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
 WORKDIR /go/src/github.com/openshift/content-mirror
 COPY . .
 RUN make build

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ci/origin-release:golang-1.23
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
 RUN GOFLAGS='' go install github.com/go-delve/delve/cmd/dlv@latest
 WORKDIR /go/src/github.com/openshift/content-mirror
 COPY . .

--- a/cmd/content-mirror/main.go
+++ b/cmd/content-mirror/main.go
@@ -68,6 +68,11 @@ type Options struct {
 // Run launches the configuration generator, the nginx process, and
 // an HTTP server for dynamic content.
 func (opt *Options) Run() error {
+	k8sDNS := os.Getenv("KUBERNETES_SERVICE_HOST")
+	if k8sDNS == "" {
+		log.Print("error: no KUBERNETES_SERVICE_HOST environment variable defined")
+		os.Exit(1)
+	}
 	t, err := template.New("config").Parse(nginxConfigTemplate)
 	if err != nil {
 		return err
@@ -79,6 +84,7 @@ func (opt *Options) Run() error {
 	}
 	cacheConfig := &config.CacheConfig{
 		LogLevel:         level,
+		K8sDNS:           k8sDNS,
 		LocalPort:        opt.LocalPort,
 		CacheDir:         opt.CacheDir,
 		MaxCacheSize:     opt.MaxCacheSize,

--- a/cmd/content-mirror/template_nginx.go
+++ b/cmd/content-mirror/template_nginx.go
@@ -15,6 +15,7 @@ http {
   sendfile     on;
   tcp_nopush   on;
   server_names_hash_bucket_size 128; # this seems to be required for some vhosts
+  resolver {{ .K8sDNS }} ipv6=off valid=30s;
 
   proxy_cache_path {{ .CacheDir }} levels=1:2 keys_zone=shared_cache:10m max_size={{ .MaxCacheSize }} inactive={{ .InactiveDuration }} use_temp_path=off;
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/content-mirror
 
-go 1.23.6
+go 1.25
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -5,6 +5,7 @@ type CacheConfig struct {
 	CacheDir         string
 	MaxCacheSize     string
 	InactiveDuration string
+	K8sDNS           string
 
 	LogLevel string
 


### PR DESCRIPTION
This will disable ipv6 which is not supported inside our clusters and force CND IP fresh, contributing to https://redhat.atlassian.net/browse/OCPCRT-187